### PR TITLE
Update cicoclient to 0.4.6

### DIFF
--- a/cico-workspace-rdo/Dockerfile
+++ b/cico-workspace-rdo/Dockerfile
@@ -10,5 +10,6 @@ RUN yum update -y && yum clean all
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py && python2 ./get-pip.py
 RUN pip install tox
 RUN pip-3 install virtualenv
+RUN yum install -y https://cbs.centos.org/kojifiles/packages/python-cicoclient/0.4.6/1.el7/noarch/python-cicoclient-0.4.6-1.el7.noarch.rpm
 
 USER 1001


### PR DESCRIPTION
This release includes support of 9-stream [1].
We're using the same command as the parent docker image [2].

[1] https://github.com/CentOS/python-cicoclient/commit/d4231c77ffc84ca62b638273433bbb258ff7443a
[2] https://github.com/centosci/images/blob/93b8d0a4f79bf26269e4d541c665623dec577c7b/cico-workspace/Dockerfile#L7