### PR TITLE
Specify correct encoding with LANG and LC_ALL

### DIFF
--- a/cico-workspace-rdo/Dockerfile
+++ b/cico-workspace-rdo/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Alfredo Moralejo <amoralej@redhat.com>
 
 USER 0
 
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 RUN rm -f /etc/yum.repos.d/infrastructure.repo
 RUN yum install -y python3 python3-pip sudo  && yum clean all
 RUN yum update -y && yum clean all


### PR DESCRIPTION
After building and pushing latest cico-workspace-rdo image
we hitted issue during pip installation in jobs [1].
We implement the workaround proposed in [2].

I reverted the docker image latest tag, it's now
pointing to previous one (i.e 1.0).

[1] https://jenkins-cloudsig-ci.apps.ocp.ci.centos.org/view/puppet-promotion-pipelines/view/Puppet%20Promotion%20Victoria/job/weirdo-generic-packstack-scenario001/853/consoleText
[2] https://github.com/pypa/pip/issues/10219